### PR TITLE
includes a -I option which parasitically saves histograms as png file…

### DIFF
--- a/include/panguinOnline.hh
+++ b/include/panguinOnline.hh
@@ -63,6 +63,7 @@ private:
   Bool_t                            fUpdate;
   Bool_t                            fFileAlive;
   Bool_t                            fPrintOnly;
+  Bool_t                            fSaveImages;
   TH1D                             *mytemp1d;
   TH2D                             *mytemp2d;
   TH3D                             *mytemp3d;
@@ -73,10 +74,11 @@ private:
   int fVerbosity;
 
 public:
-  OnlineGUI(OnlineConfig&, Bool_t,int);
+  OnlineGUI(OnlineConfig&, Bool_t,int, Bool_t);
   void CreateGUI(const TGWindow *p, UInt_t w, UInt_t h);
   virtual ~OnlineGUI();
   void DoDraw();
+  void SaveImage(TObject* o,std::map<TString,TString> &command);
   void DrawPrev();
   void DrawNext();
   void DoListBox(Int_t id);

--- a/panguin.cc
+++ b/panguin.cc
@@ -10,7 +10,7 @@ using namespace std;
 
 clock_t tStart;
 void Usage();
-void online(TString type="standard",UInt_t run=0,Bool_t printonly=kFALSE, int verbosity=0);
+void online(TString type="standard",UInt_t run=0,Bool_t printonly=kFALSE, int verbosity=0, Bool_t saveImages=kFALSE);
 
 int main(int argc, char **argv){
   tStart = clock();
@@ -18,6 +18,7 @@ int main(int argc, char **argv){
   TString type="default";
   UInt_t run=0;
   Bool_t printonly=kFALSE;
+  Bool_t saveImages=kFALSE;
   Bool_t showedUsage=kFALSE;
   int verbosity(0);
 
@@ -45,6 +46,9 @@ int main(int argc, char **argv){
     } else if (sArg=="-P") {
       printonly = kTRUE;
       cout <<  " PrintOnly" << endl;
+    } else if (sArg=="-I") {
+      saveImages = kTRUE;
+      cout <<  " save Images" << endl;
     } else if (sArg=="-h") {
       if(!showedUsage) Usage();
       showedUsage=kTRUE;
@@ -68,7 +72,7 @@ int main(int argc, char **argv){
     gROOT->ProcessLine(".x ~/rootlogon.C");
   }
   
-  online(type,run,printonly,verbosity);
+  online(type,run,printonly,verbosity,saveImages);
   theApp.Run();
 
   cout<<"Done. Time passed: "
@@ -78,7 +82,7 @@ int main(int argc, char **argv){
 }
 
 
-void online(TString type,UInt_t run,Bool_t printonly, int ver){
+void online(TString type,UInt_t run,Bool_t printonly, int ver, Bool_t saveImages){
 
   if(printonly) {
     if(!gROOT->IsBatch()) {
@@ -100,7 +104,7 @@ void online(TString type,UInt_t run,Bool_t printonly, int ver){
   cout<<"Finished processing cfg. Init OnlineGUI. Time passed: "
       <<(double) ((clock() - tStart)/CLOCKS_PER_SEC)<<" s!"<<endl;
 
-  new OnlineGUI(*fconfig,printonly,ver);
+  new OnlineGUI(*fconfig,printonly,ver,saveImages);
 
   cout<<"Finished init OnlineGUI. Time passed: "
       <<(double) ((clock() - tStart)/CLOCKS_PER_SEC)<<" s!"<<endl;

--- a/src/panguinOnline.cc
+++ b/src/panguinOnline.cc
@@ -42,7 +42,7 @@ using namespace std;
 //
 //
 
-OnlineGUI::OnlineGUI(OnlineConfig& config, Bool_t printonly=0, int ver=0):
+OnlineGUI::OnlineGUI(OnlineConfig& config, Bool_t printonly=0, int ver=0, Bool_t saveImages=0):
   runNumber(0),
   timer(0), 
   timerNow(0),
@@ -60,6 +60,10 @@ OnlineGUI::OnlineGUI(OnlineConfig& config, Bool_t printonly=0, int ver=0):
     if(fVerbosity>1){
       cout<<"Set 2D default bins to x, y: "<<bin2Dx<<", "<<bin2Dy<<endl;
     }
+  }
+
+  if(saveImages) {
+      fSaveImages=kTRUE;
   }
 
   if(printonly) {
@@ -885,7 +889,17 @@ Int_t OnlineGUI::OpenRootFile() {
   return 0;
 
 }
-
+void OnlineGUI::SaveImage(TObject* o,std::map<TString,TString> &command)
+{
+  if(this->fSaveImages)
+      {
+        cout<<"saving image "<< command["variable"] <<endl;
+        TCanvas *c = new TCanvas("c","c",gPad->GetWw(),gPad->GetWh());
+        o->Draw(command["drawopt"]);
+        c->Print("hydra_"+command["variable"]+".png");
+        delete c;
+      }
+}
 void OnlineGUI::HistDraw(std::map<TString,TString> &command) {
   // Called by DoDraw(), this will plot a histogram.
 
@@ -953,6 +967,8 @@ void OnlineGUI::HistDraw(std::map<TString,TString> &command) {
 	    mytemp1d->SetStats(showstat);
 	    if( newtitle != "" ) mytemp1d->SetTitle(newtitle);
 	    mytemp1d->Draw(drawopt);
+
+      SaveImage(mytemp1d, command);
 	  }
 	}
 	break;
@@ -979,6 +995,7 @@ void OnlineGUI::HistDraw(std::map<TString,TString> &command) {
 	  if( newtitle != "" ) mytemp2d->SetTitle(newtitle);
 	  mytemp2d->SetStats(showstat);
 	  mytemp2d->Draw(drawopt);
+    SaveImage(mytemp2d, command);
 	  // 	  }
 	}
 	break;
@@ -999,6 +1016,8 @@ void OnlineGUI::HistDraw(std::map<TString,TString> &command) {
 	  } else {
 	    mytemp3d->Draw(drawopt);
 	  }
+
+    SaveImage(mytemp3d, command);
 	}
 	break;
       }
@@ -1093,6 +1112,7 @@ void OnlineGUI::TreeDraw(map<TString,TString> &command) {
         TString myMD5 = tmpstring.MD5();
 	TH1* thathist = (TH1*)hobj;
 	thathist->SetNameTitle(myMD5,command["title"]);
+  SaveImage(thathist, command);
       }
     } else {
       BadDraw("Empty Histogram");


### PR DESCRIPTION
…s without altering normal running or configuration files.  This is necessary for future integration with the Hydra system.

The histograms are drawn with the same exact draw options as configured.  The images are named by the variable which is drawn and prepended with "hydra_" in order to avoid stepping on toes.