### PR TITLE
Bugfixes related to file paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 
 # Name of this project
-project(panguin LANGUAGES CXX VERSION 2.1)
+project(panguin LANGUAGES CXX VERSION 2.2)
 
 # Install in GNU-style directory layout  (copied from japan/CMakeLists.txt)
 include(GNUInstallDirs)

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ one output file per page is generated, and the file name is
 generated from the pattern specified by the `protoplotpagefile`
 command (see later).
 
-### -C,--config-dir \<dir\>
+### -C,--config-dir \<path\>
 
 Search for configuration files and plot macros in the given directory or
 directory path (= list of directories separated by colons). The current working
@@ -111,7 +111,7 @@ automatically appended to the configuration directory search path
 (even if --config-dir isn't given on the command line). It is usually more 
 convenient to set this variable instead of using the command line option.
 
-### --root-dir \<dir\>
+### --root-dir \<path\>
 
 Specifies the search directory or path for ROOT files, similar to
 --config-dir.

--- a/include/panguinOnlineConfig.hh
+++ b/include/panguinOnlineConfig.hh
@@ -116,6 +116,7 @@ public:
   int GetRunNumber() const { return fRunNumber; }
   std::string SubstituteRunNumber( std::string str, int runnumber ) const;
 
+  const std::string& GetConfFilePath() const { return fConfFilePath; }
   const std::string& GetGuiDirectory() const { return fConfFileDir; }
   const std::string& GetConfFileName() const { return confFileName; }
   void Get2DnumberBins( int& nX, int& nY ) const

--- a/panguin.cc
+++ b/panguin.cc
@@ -9,7 +9,7 @@
 #include <string>
 #include <stdexcept>
 
-#define PANGUIN_VERSION "Panguin version 2.1 (24-Aug-2022)"
+#define PANGUIN_VERSION "Panguin version 2.2 (31-Aug-2022)"
 
 using namespace std;
 

--- a/panguin.cc
+++ b/panguin.cc
@@ -108,9 +108,9 @@ void online( const OnlineConfig::CmdLineOpts& opts )
 
   TString macropath = gROOT->GetMacroPath();
   macropath += ":./macros";   // for backward compatibility
-  TString guidir = fconfig.GetGuiDirectory();
-  if( !guidir.IsNull() )
-    macropath = ".:" + guidir + ":" + macropath;
+  TString guipath = fconfig.GetConfFilePath();
+  if( !guipath.IsNull() )
+    macropath = ".:" + guipath + ":" + macropath;
   gROOT->SetMacroPath(macropath);
 
   if( opts.run != 0 ) {

--- a/panguin.cc
+++ b/panguin.cc
@@ -41,11 +41,12 @@ int main( int argc, char** argv )
                  "Plot format (pdf, png, jpg ...)")
     ->type_name("<fmt>");
   cli.add_option("-C,--config-dir", cfgdir,
-                 "Configuration directory or path (: separated)")
-    ->type_name("<dir>");
+                 "Search path for configuration files & macros "
+                 "(\":\"-separated)")
+    ->type_name("<path>");
   cli.add_option("--root-dir", rootdir,
-                 "ROOT files directory or path (: separated)")
-    ->type_name("<dir>");
+                 "ROOT files search path (\":\"-separated)")
+    ->type_name("<path>");
   cli.add_option("-O,--plots-dir", pltdir,
                  "Output directory for summary plots")
     ->type_name("<dir>");

--- a/panguin.cc
+++ b/panguin.cc
@@ -7,6 +7,7 @@
 #include <iostream>
 #include <ctime>
 #include <string>
+#include <stdexcept>
 
 #define PANGUIN_VERSION "Panguin version 2.1 (24-Aug-2022)"
 
@@ -24,71 +25,77 @@ int main( int argc, char** argv )
   bool printonly{false};
   bool saveImages{false};
 
-  CLI::App cli("panguin: configurable ROOT data visualization tool");
+  try {
+    CLI::App cli("panguin: configurable ROOT data visualization tool");
 
-  cli.add_option("-f,--config-file", cfgfile,
-                 "Job configuration file")
-    ->capture_default_str()->type_name("<file name>");
-  cli.add_option("-r,--run", run,
-                 "Run number")
-    ->type_name("<run number>");
-  cli.add_option("-R,--root-file", rootfile,
-                 "ROOT file to process")
-    ->type_name("<file name>");
-  cli.add_flag("-P,-b,--batch", printonly,
-               "No GUI. Save plots to summary file(s)");
-  cli.add_option("-E,--plot-format", plotfmt,
-                 "Plot format (pdf, png, jpg ...)")
-    ->type_name("<fmt>");
-  cli.add_option("-C,--config-dir", cfgdir,
-                 "Search path for configuration files & macros "
-                 "(\":\"-separated)")
-    ->type_name("<path>");
-  cli.add_option("--root-dir", rootdir,
-                 "ROOT files search path (\":\"-separated)")
-    ->type_name("<path>");
-  cli.add_option("-O,--plots-dir", pltdir,
-                 "Output directory for summary plots")
-    ->type_name("<dir>");
-  cli.add_flag("-I,--images", saveImages,
-               "Save individual plots as images (implies -P)");
-  cli.add_option("-F,--image-format", imgfmt,
-                 "Image file format (png, jpg ...)")
-    ->type_name("<fmt>");
-  cli.add_option("-H,--images-dir", imgdir,
-                 "Output directory for individual images (default: plots-dir)")
-    ->type_name("<dir>");
-  cli.add_option("-v,--verbosity", verbosity,
-                 "Set verbosity level (>=0)")
-    ->type_name("<level>");
-  cli.set_version_flag("-V,--version", PANGUIN_VERSION);
+    cli.add_option("-f,--config-file", cfgfile,
+                   "Job configuration file")
+      ->capture_default_str()->type_name("<file name>");
+    cli.add_option("-r,--run", run,
+                   "Run number")
+      ->type_name("<run number>");
+    cli.add_option("-R,--root-file", rootfile,
+                   "ROOT file to process")
+      ->type_name("<file name>");
+    cli.add_flag("-P,-b,--batch", printonly,
+                 "No GUI. Save plots to summary file(s)");
+    cli.add_option("-E,--plot-format", plotfmt,
+                   "Plot format (pdf, png, jpg ...)")
+      ->type_name("<fmt>");
+    cli.add_option("-C,--config-dir", cfgdir,
+                   "Search path for configuration files & macros "
+                   "(\":\"-separated)")
+      ->type_name("<path>");
+    cli.add_option("--root-dir", rootdir,
+                   "ROOT files search path (\":\"-separated)")
+      ->type_name("<path>");
+    cli.add_option("-O,--plots-dir", pltdir,
+                   "Output directory for summary plots")
+      ->type_name("<dir>");
+    cli.add_flag("-I,--images", saveImages,
+                 "Save individual plots as images (implies -P)");
+    cli.add_option("-F,--image-format", imgfmt,
+                   "Image file format (png, jpg ...)")
+      ->type_name("<fmt>");
+    cli.add_option("-H,--images-dir", imgdir,
+                   "Output directory for individual images (default: plots-dir)")
+      ->type_name("<dir>");
+    cli.add_option("-v,--verbosity", verbosity,
+                   "Set verbosity level (>=0)")
+      ->type_name("<level>");
+    cli.set_version_flag("-V,--version", PANGUIN_VERSION);
 
-  CLI11_PARSE(cli, argc, argv);
+    CLI11_PARSE(cli, argc, argv);
 
-  if( saveImages ) {
-    printonly = true;
-    if( imgdir.empty() )
-      imgdir = pltdir;
+    if( saveImages ) {
+      printonly = true;
+      if( imgdir.empty() )
+        imgdir = pltdir;
+    }
+
+    if( verbosity <= 0 ) {
+      verbosity = 0;
+    } else if( verbosity > 0 ) {
+      cout << cli.config_to_str(true, false);
+    }
+
+    if( !gSystem->AccessPathName("./rootlogon.C") ) {
+      gROOT->ProcessLine(".x rootlogon.C");
+    }
+
+    if( !gSystem->AccessPathName("~/rootlogon.C") ) {
+      gROOT->ProcessLine(".x ~/rootlogon.C");
+    }
+
+    TApplication theApp("panguin2", &argc, argv, nullptr, -1);
+    online({cfgfile, cfgdir, rootfile, rootdir, plotfmt, imgfmt, pltdir,
+            imgdir, run, verbosity, printonly, saveImages});
+    theApp.Run();
+
+  } catch ( const exception& e ) {
+    cerr << "Error while running panguin: " << e.what() << endl;
+    return 1;
   }
-
-  if( verbosity <= 0 ) {
-    verbosity = 0;
-  } else if( verbosity > 0 ) {
-    cout << cli.config_to_str(true, false);
-  }
-
-  if( !gSystem->AccessPathName("./rootlogon.C") ) {
-    gROOT->ProcessLine(".x rootlogon.C");
-  }
-
-  if( !gSystem->AccessPathName("~/rootlogon.C") ) {
-    gROOT->ProcessLine(".x ~/rootlogon.C");
-  }
-
-  TApplication theApp("panguin2", &argc, argv, nullptr, -1);
-  online({cfgfile, cfgdir, rootfile, rootdir, plotfmt, imgfmt, pltdir, imgdir,
-          run, verbosity, printonly, saveImages});
-  theApp.Run();
 
   return 0;
 }

--- a/src/panguinOnlineConfig.cc
+++ b/src/panguinOnlineConfig.cc
@@ -326,8 +326,12 @@ OnlineConfig::OnlineConfig( const CmdLineOpts& opts )
   confFileName = BasenameStr(confFileName);
 
   // Ensure that fConfFilePath contains any relative path from confFileName
-  if( fConfFileDir != "." && cfgpath.find(fConfFileDir) == string::npos )
-    cfgpath = cfgpath.empty() ? fConfFileDir : fConfFileDir + ":" + cfgpath;
+  if( fConfFileDir != "." ) {
+    auto pos = cfgpath.find(fConfFileDir);
+    if( pos == string::npos || (pos + fConfFileDir.length() < cfgpath.size()
+                                && cfgpath[pos + cfgpath.length()] != ':') )
+      cfgpath = cfgpath.empty() ? fConfFileDir : fConfFileDir + ":" + cfgpath;
+  }
   fConfFilePath = std::move(cfgpath);
 
   string fullpath = fConfFileDir + "/" + confFileName;


### PR DESCRIPTION
This PR should fix the following bugs observed during testing:
- The full configuration file path (specified with `-C` and/or `$PANGUIN_CONFIG_PATH`) was not added to the macro path.
- Environment variables and tilde characters given on the command line or within environment variables were not expanded since it was mistakenly expected that the shell would perform the expansion.
- In certain cases, a path specified as part of the configuration file name was not added to the configuration file path.

The program version number is increased to 2.2.
