### PR TITLE
Bugfixes for run number and rootfile name handling

### DIFF
--- a/panguin.cc
+++ b/panguin.cc
@@ -121,15 +121,5 @@ void online( const OnlineConfig::CmdLineOpts& opts )
     macropath = ".:" + guipath + ":" + macropath;
   gROOT->SetMacroPath(macropath);
 
-  if( opts.run != 0 ) {
-    if( !opts.rootfile.empty() )
-      cerr << "Warning: Both ROOT file and run number specified. "
-           << "ROOT file will be ignored." << endl;
-    if( fconfig.GetRunNumber() != 0 && fconfig.GetRunNumber() != opts.run )
-      cerr << "Warning: Run number extracted from ROOT file name differs from "
-              "the one requested on the command line: "
-           << fconfig.GetRunNumber() << " vs. " << opts.run << endl;
-  }
-
   new OnlineGUI(std::move(fconfig));
 }

--- a/panguin.cc
+++ b/panguin.cc
@@ -129,7 +129,6 @@ void online( const OnlineConfig::CmdLineOpts& opts )
       cerr << "Warning: Run number extracted from ROOT file name differs from "
               "the one requested on the command line: "
            << fconfig.GetRunNumber() << " vs. " << opts.run << endl;
-    fconfig.OverrideRootFile(opts.run);
   }
 
   new OnlineGUI(std::move(fconfig));

--- a/src/panguinOnlineConfig.cc
+++ b/src/panguinOnlineConfig.cc
@@ -529,8 +529,14 @@ bool OnlineConfig::ParseConfig()
       }},
       {"rootfile",
         1, [&]( const VecStr_t& line ) {
-        if( !IsSet(rootfilename, line[0]) )
-          rootfilename = line[1];
+        if( !IsSet(rootfilename, line[0]) ) {
+          if( fRunNumber != 0 )
+            cout << "Warning: Run number set on command line. "
+                 << "Ignoring rootfile specification from config file."
+                 << endl;
+          else
+            rootfilename = line[1];
+        }
       }},
       {"goldenrootfile",
         1, [&]( const VecStr_t& line ) {

--- a/src/panguinOnlineConfig.cc
+++ b/src/panguinOnlineConfig.cc
@@ -233,7 +233,7 @@ static int ExtractRunNumber( const string& filename )
     auto next = pos + 1;
     int k = 0;
     while( ++pos < len && isdigit(filename[pos]) && ++k < 5 );
-    if( k >= 4 && ++pos < len && (filename[pos] == '.' || filename[pos] == '_') ) {
+    if( k >= 4 && pos + 1 < len && (filename[pos] == '.' || filename[pos] == '_') ) {
       return stoi(filename.substr(pos - k, k));
     }
     pos = next;

--- a/src/panguinOnlineConfig.cc
+++ b/src/panguinOnlineConfig.cc
@@ -232,8 +232,8 @@ static int ExtractRunNumber( const string& filename )
   while( (pos = filename.find('_', pos)) != string::npos ) {
     auto next = pos + 1;
     int k = 0;
-    while( ++pos < len && isdigit(filename[pos]) && ++k < 5 );
-    if( k >= 4 && pos + 1 < len && (filename[pos] == '.' || filename[pos] == '_') ) {
+    while( ++pos < len && isdigit(filename[pos]) && ++k <= 5 ) ;
+    if( k >= 4 && pos < len && (filename[pos] == '.' || filename[pos] == '_') ) {
       return stoi(filename.substr(pos - k, k));
     }
     pos = next;


### PR DESCRIPTION
If the rootfile name is specified on the commandline, it will take precedence over either a "rootfile" or "protorootfile" specified in the configuration file.

The extraction of the run number from the specified rootfile name now works properly for either 4 or 5 digit run numbers that are preceded by an underscore and followed by a period or underscore.

If the rootfile name and run number are both specified on the command line, the specified rootfile will be opened and the run number will be interpreted as the commandline value (not the value extracted from the rootfile name).

If the configuration file contains both a "rootfile" and "protorootfile" value, and the run number is specified on the command line, the rootfile generated using the protorootfile will be used.

