### PR TITLE
Goldenrootfile option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,21 +7,7 @@ project(panguin LANGUAGES CXX VERSION 2.4)
 # Install in GNU-style directory layout  (copied from japan/CMakeLists.txt)
 include(GNUInstallDirs)
 
-
 message(STATUS "System name ${CMAKE_SYSTEM_NAME}")
-#MAC specific variable
-if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-    set(CMAKE_MACOSX_RPATH ON)
-    set(CMAKE_SKIP_BUILD_RPATH FALSE)
-    set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
-    set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
-    set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
-    list(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_INSTALL_PREFIX}/lib" isSystemDir)
-    if("${isSystemDir}" STREQUAL "-1")
-        set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
-    endif()
-endif()
-
 # Local path for cmake modules, before ${CMAKE_ROOT}/Modules/ is checked
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/modules")
 
@@ -31,9 +17,24 @@ if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
   message(STATUS "    Use -DCMAKE_INSTALL_PREFIX=/usr/local to set to something else" )
   set (CMAKE_INSTALL_PREFIX "${CMAKE_SOURCE_DIR}"
         CACHE PATH "default install path" FORCE )
-else()
-  set(CMAKE_INSTALL_PREFIX ${CMAKE_SOURCE_DIR})
-  set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
+endif()
+
+# RPATH handling
+if(UNIX)
+  set(CMAKE_SKIP_BUILD_RPATH FALSE)
+  set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+  list(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_INSTALL_FULL_LIBDIR}" isSystemDir)
+  # Only set RPATH if not installing into a system directory
+  if(isSystemDir STREQUAL "-1")
+    if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
+      # Linux etc.
+      set(CMAKE_INSTALL_RPATH "\$ORIGIN/../${CMAKE_INSTALL_LIBDIR}")
+    else()
+      # macOS
+      set(CMAKE_MACOSX_RPATH ON)
+      set(CMAKE_INSTALL_RPATH "@loader_path/../${CMAKE_INSTALL_LIBDIR}")
+    endif()
+  endif()
 endif()
 
 # Load ROOT and setup include directory

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 
 # Name of this project
-project(panguin LANGUAGES CXX VERSION 2.4)
+project(panguin LANGUAGES CXX VERSION 2.5)
 
 # Install in GNU-style directory layout  (copied from japan/CMakeLists.txt)
 include(GNUInstallDirs)

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ be interpreted, for example the event header branch.
 The build system is a standard CMake setup. CMake version 3 is required. In the 
 source directory of Panguin, do
 ```
-source /path/to/ROOT/bin/thisroot.sh
+source /path/to/ROOT/bin/thisroot.sh # or "module load root"
+export ANALYZER=/path/to/analyzer    # or "module load analyzer". Optional.
 cmake -S . -B build 
 cmake --build build -j4
 ```

--- a/README.md
+++ b/README.md
@@ -82,6 +82,11 @@ a 4- or 5-digit number preceded by an underscore and followed by either a
 dot or an underscore). If the run number cannot be determined in this way,
 it will be omitted from the generated plots.
 
+### -G, --goldenroot-file \<file name\>
+
+Name of ROOT file with reference plots. If the file is not found, a warning 
+is printed, and no reference plots are generated.
+
 ### -E,--plot-format \<fmt\>
 
 Sets the output plot file format. The default is `pdf`. Also supported
@@ -229,10 +234,11 @@ Following is the list of options recognized in the prologue.
   example, finding ROOT files that differ in a common prefix, such as a DAQ
   configuration. This works well if run numbers are unique, but text parts of
   the file name may vary.
-- **goldenrootfile \<file name\>** selects a file to draw as a comparison for
-  the current file to more easily notice problems with the current run. If the
-  specified file is not found, a warning is printed, and plots are generated
-  without the comparison data.
+- **goldenrootfile \<file name\>** selects a ROOT file containing comparison 
+  plots (reference spectra) to help spot problems with the current run.
+  Reference plots will be overlaid onto the current spectra with a green hatch 
+  pattern. If the specified ROOT file is not found, a warning is printed, and no
+  comparison plots are generated. Equivalent to --goldenroot-file.
 - **rootfilespath \<directory path\>** specifies a path for searching for ROOT
   files (whether specified with `rootfile`, `protorootfile`, or
   `goldenrootfile`). Equivalent to --root-dir. If both --root-dir and

--- a/include/panguinOnline.hh
+++ b/include/panguinOnline.hh
@@ -104,8 +104,9 @@ public:
   static void BadDraw( const TString& );
   void CheckRootFile();
   Int_t OpenRootFile();
+  Int_t PrepareRootFiles();
   void PrintToFile();
-  Int_t PrintPages();
+  void PrintPages();
   void MyCloseWindow();
   void CloseGUI();
   void SetVerbosity( int ver ) { fVerbosity = ver; }

--- a/include/panguinOnline.hh
+++ b/include/panguinOnline.hh
@@ -71,11 +71,11 @@ class OnlineGUI {
 
   std::string SubstitutePlaceholders(
     std::string str, const std::string& var = std::string() ) const;
+  void DeleteGUI();
 
 public:
   using cmdmap_t = std::map<std::string, std::string>;
-  explicit OnlineGUI( const OnlineConfig& config );
-  explicit OnlineGUI( OnlineConfig&& config );
+  explicit OnlineGUI( OnlineConfig config );
   void CreateGUI( const TGWindow* p, UInt_t w, UInt_t h );
   virtual ~OnlineGUI();
   void DoDraw();
@@ -84,7 +84,8 @@ public:
   void DoListBox( Int_t id );
   void CheckPageButtons();
   // Specific Draw Methods
-  Bool_t IsHistogram( const TString& );
+  Bool_t IsHistogram( const TString& objectname );
+  Bool_t IsPrintOnly() const { return fPrintOnly; }
   void GetFileObjects();
   void GetTreeVars();
   void GetRootTree();
@@ -104,7 +105,7 @@ public:
   void CheckRootFile();
   Int_t OpenRootFile();
   void PrintToFile();
-  void PrintPages();
+  Int_t PrintPages();
   void MyCloseWindow();
   void CloseGUI();
   void SetVerbosity( int ver ) { fVerbosity = ver; }

--- a/include/panguinOnlineConfig.hh
+++ b/include/panguinOnlineConfig.hh
@@ -79,12 +79,14 @@ public:
     explicit CmdLineOpts(std::string f)
       : cfgfile(std::move(f))
     {}
-    CmdLineOpts(std::string f, std::string d, std::string rf, std::string rd,
-                std::string pf, std::string ifm, std::string pd,
-                std::string id, int rn, int v, bool po, bool si)
+    CmdLineOpts( std::string f, std::string d, std::string rf,
+                 std::string gf, std::string rd, std::string pf,
+                 std::string ifm, std::string pd, std::string id,
+                 int rn, int v, bool po, bool si )
       : cfgfile(std::move(f))
       , cfgdir(std::move(d))
       , rootfile(std::move(rf))
+      , goldenfile(std::move(gf))
       , rootdir(std::move(rd))
       , plotfmt(std::move(pf))
       , imgfmt(std::move(ifm))
@@ -98,6 +100,7 @@ public:
     std::string cfgfile;
     std::string cfgdir;
     std::string rootfile;
+    std::string goldenfile;
     std::string rootdir;
     std::string plotfmt;
     std::string imgfmt;

--- a/panguin.cc
+++ b/panguin.cc
@@ -8,7 +8,7 @@
 #include <stdexcept>
 #include <memory>
 
-#define PANGUIN_VERSION "Panguin version 2.4 (07-Oct-2022)"
+#define PANGUIN_VERSION "Panguin version 2.5 (23-Oct-2022)"
 
 using namespace std;
 

--- a/panguin.cc
+++ b/panguin.cc
@@ -17,7 +17,7 @@ void online( const OnlineConfig::CmdLineOpts& opts );
 
 int main( int argc, char** argv )
 {
-  string cfgfile{"default.cfg"}, rootfile;
+  string cfgfile{"default.cfg"}, rootfile, goldenfile;
   string plotfmt, imgfmt;
   string cfgdir, rootdir, pltdir, imgdir;
   int run{0};
@@ -36,6 +36,9 @@ int main( int argc, char** argv )
       ->type_name("<run number>");
     cli.add_option("-R,--root-file", rootfile,
                    "ROOT file to process")
+      ->type_name("<file name>");
+    cli.add_option("-G,--goldenroot-file", goldenfile,
+                   "Reference ROOT file")
       ->type_name("<file name>");
     cli.add_flag("-P,-b,--batch", printonly,
                  "No GUI. Save plots to summary file(s)");
@@ -88,8 +91,8 @@ int main( int argc, char** argv )
     }
 
     TApplication theApp("panguin2", &argc, argv, nullptr, -1);
-    online({cfgfile, cfgdir, rootfile, rootdir, plotfmt, imgfmt, pltdir,
-            imgdir, run, verbosity, printonly, saveImages});
+    online({cfgfile, cfgdir, rootfile,  goldenfile, rootdir, plotfmt, imgfmt,
+            pltdir, imgdir, run, verbosity, printonly, saveImages});
     theApp.Run();
 
   } catch ( const exception& e ) {

--- a/src/panguinOnline.cc
+++ b/src/panguinOnline.cc
@@ -127,7 +127,7 @@ string OnlineGUI::SubstitutePlaceholders( string str, const string& var ) const
   ostr.str("");
   if( fConfig.GetPageNoWidth() > 0 )
     ostr << setw(fConfig.GetPageNoWidth()) << setfill('0');
-  ostr << current_page;
+  ostr << current_page + 1;
   str = ReplaceAll(str, "%P", ostr.str());
   // Pad number
   ostr.clear();
@@ -136,6 +136,7 @@ string OnlineGUI::SubstitutePlaceholders( string str, const string& var ) const
     ostr << setw(fConfig.GetPadNoWidth()) << setfill('0');
   ostr << current_pad;
   str = ReplaceAll(str, "%D", ostr.str());
+  // Plot and image formats
   str = ReplaceAll(str, "%E", fConfig.GetPlotFormat());
   str = ReplaceAll(str, "%F", fConfig.GetImageFormat());
   return str;
@@ -1321,14 +1322,14 @@ Int_t OnlineGUI::PrintPages()
     DoDraw();
     TString pagename = pagehead;
     pagename += " ";
-    pagename += i;
+    pagename += i + 1;
     pagename += ": ";
     pagename += fConfig.GetPageTitle(current_page);
     lt->SetTextSize(0.025);
     lt->DrawLatex(0.05, 0.98, pagename);
     if( pagePrint ) {
       filename = SubstitutePlaceholders(protofilename);
-      cout << "Printing page " << current_page
+      cout << "Printing page " << current_page + 1
            << " to file = " << filename << endl;
       auto outdir = DirnameStr(filename.Data());
       if( MakePlotsDir(outdir) )

--- a/src/panguinOnlineConfig.cc
+++ b/src/panguinOnlineConfig.cc
@@ -273,6 +273,7 @@ OnlineConfig::OnlineConfig( const string& config_file_name )
 OnlineConfig::OnlineConfig( const CmdLineOpts& opts )
   : confFileName(opts.cfgfile)
   , rootfilename(opts.rootfile)
+  , goldenrootfilename(opts.goldenfile)
   , fRootFilesPath(opts.rootdir)
   , fPlotFormat(opts.plotfmt)
   , fImageFormat(opts.imgfmt)
@@ -296,6 +297,7 @@ OnlineConfig::OnlineConfig( const CmdLineOpts& opts )
   try {
     confFileName = ExpandFileName(confFileName);
     rootfilename = ExpandFileName(rootfilename);
+    goldenrootfilename = ExpandFileName(goldenrootfilename);
     fRootFilesPath = ExpandFileName(fRootFilesPath);
     fImagesDir = ExpandFileName(fImagesDir);
     plotsdir = ExpandFileName(plotsdir);
@@ -540,7 +542,8 @@ bool OnlineConfig::ParseConfig()
       }},
       {"goldenrootfile",
         1, [&]( const VecStr_t& line ) {
-        goldenrootfilename = ExpandFileName(line[1]);
+        if( !IsSet(goldenrootfilename, line[0]) )
+          goldenrootfilename = ExpandFileName(line[1]);
       }},
       {"protorootfile",
         1, [&]( const VecStr_t& line ) {

--- a/src/panguinOnlineConfig.cc
+++ b/src/panguinOnlineConfig.cc
@@ -9,6 +9,7 @@
 #include <iomanip>    // quoted, setw, setfill
 #include <cctype>     // isalnum, isdigit
 #include <algorithm>  // find_if
+#include <type_traits>// make_signed
 #include <sys/stat.h>
 #if __cplusplus >= 201703L
 #include <regex>
@@ -140,7 +141,8 @@ static string ExpandFileName( string str )
   if( str.size() < 2 )
     return str;
   while( (pos = str.find('$')) != string::npos ) {
-    auto iend = find_if(str.begin() + pos + 1, str.end(), []( int c ) {
+    auto spos = static_cast<make_signed<decltype(pos)>::type>(pos);
+    auto iend = find_if(str.begin() + spos + 1, str.end(), []( int c ) {
       return (!isalnum(c) && c != '_');
     });
     auto len = iend - str.begin() - pos - 1;
@@ -354,7 +356,7 @@ OnlineConfig::OnlineConfig( const CmdLineOpts& opts )
 }
 
 //_____________________________________________________________________________
-int OnlineConfig::CheckLoadIncludeFile(
+int OnlineConfig::CheckLoadIncludeFile( // NOLINT(misc-no-recursion)
   const string& sline, const std::vector<std::string>& strvect )
 {
   if( strvect[0] == "include" ) {
@@ -385,7 +387,7 @@ int OnlineConfig::CheckLoadIncludeFile(
 // Reads in the Config File, and makes the proper calls to put
 //  the information contained into memory.
 // Returns -1 on error, otherwise the number of include files loaded (usually 0).
-int OnlineConfig::LoadFile( std::ifstream& infile, const string& filename )
+int OnlineConfig::LoadFile( std::ifstream& infile, const string& filename ) // NOLINT(misc-no-recursion)
 {
   if( !infile )
     return -1;

--- a/src/panguinOnlineConfig.cc
+++ b/src/panguinOnlineConfig.cc
@@ -792,7 +792,7 @@ pair<uint_t, uint_t> OnlineConfig::GetPageDim( uint_t page )
 }
 
 //_____________________________________________________________________________
-// Returns the title of the page.
+// Returns the title of the page. Page numbers start at 1.
 //  if it is not defined in the config, then return "Page #"
 string OnlineConfig::GetPageTitle( uint_t page )
 {
@@ -812,7 +812,7 @@ string OnlineConfig::GetPageTitle( uint_t page )
     }
   }
   title = "Page ";
-  title += to_string(page);
+  title += to_string(page+1);
   return title;
 }
 


### PR DESCRIPTION
- Add -G/--goldenroot-file command line option to allow specifying the golden root file. As usual, the command line will take precedence over the "goldenrootfile" option in the configuration file.
- Change user-facing page numbers to start counting at 1, analogous to pad numbers. This affects summary file names and page titles.
- Fix broken CMake install prefix and RPATH handling
- Small performance improvements and code cleanup
- Update documentation
- Advance program version to 2.5