### PR TITLE
Panguin v2.6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,10 +53,10 @@ endif()
 
 # CLI11 command line parser
 file(DOWNLOAD
-  "https://github.com/CLIUtils/CLI11/releases/download/v2.2.0/CLI11.hpp"
+  "https://github.com/CLIUtils/CLI11/releases/download/v2.3.2/CLI11.hpp"
   "${CMAKE_BINARY_DIR}/CLI11.hpp"
   EXPECTED_HASH
-    SHA256=e0bd8d113ed526ca9a86fafa8f7e0c51dc9d20821c4d0fd3a8697f21c049722c
+    SHA256=ba83806399a66634ca8f8d292df031e5ed651315ceb9a6a09ba56f88d75f1797
   STATUS _ret
 )
 list(GET _ret 0 _retcode)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 
 # Name of this project
-project(panguin LANGUAGES CXX VERSION 2.5)
+project(panguin LANGUAGES CXX VERSION 2.6)
 
 # Install in GNU-style directory layout  (copied from japan/CMakeLists.txt)
 include(GNUInstallDirs)

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ it will be omitted from the generated plots.
 Name of ROOT file with reference plots. If the file is not found, a warning 
 is printed, and no reference plots are generated.
 
-### -E,--plot-format \<fmt\>
+### -E, --plot-format \<fmt\>
 
 Sets the output plot file format. The default is `pdf`. Also supported
 are `png`, `gif`, `jpg`, `ps` and `eps`. For formats other than `pdf`,
@@ -96,7 +96,7 @@ one output file per page is generated, and the file name is
 generated from the pattern specified by the `protoplotpagefile`
 command (see later).
 
-### -C,--config-dir \<path\>
+### -C, --config-path, --config-dir \<path\>
 
 Search for configuration files and plot macros in the given directory or
 directory path (= list of directories separated by colons). The current working
@@ -125,14 +125,14 @@ Specifies the search directory or path for ROOT files, similar to
 The contents of the environment variable `ROOTFILES` are automatically
 appended to this path (even if --root-dir isn't given on the command line).
 
-### -O,--plots-dir \<dir\>
+### -O, --plots-dir \<dir\>
 
 Specifies the directory where summary plots should be written.
 This directory will be created if it does not exist, permissions allowing.
 The value specified here will be ignored if `protoplotfile` or
 `protoplotpagefile` are absolute paths.
 
-### -I,--images
+### -I, --images
 
 Save each individual plots as an image file. This option automatically
 enables batch mode (-P). Summary plots continue to be generated in addition
@@ -140,12 +140,12 @@ to the individual image files. The image file name patterns can be
 customized with the `protoimagefile` and `protomacroimagefile` commands
 in the configuration file.
 
-### -F,--image-format \<fmt\>
+### -F, --image-format \<fmt\>
 
 Define the file format for individual image files. The default is `png`.
 See the descrption of --plot-format.
 
-### -H,--images-dir \<dir\>
+### -H, --images-dir \<dir\>
 
 Like --plots-dir, defines the directory where individual image files are
 written. The default is the same directory as --plots-dir. 

--- a/include/panguinOnlineConfig.hh
+++ b/include/panguinOnlineConfig.hh
@@ -62,12 +62,12 @@ class OnlineConfig {
                             const VecStr_t& strvect );
 
   struct CommandDef {
-    CommandDef( std::string c, size_t n,
-                std::function<void(const VecStr_t&)> a )
-      : cmd(std::move(c)), narg(n), action(std::move(a)) {}
-    std::string cmd;
-    size_t narg = 0;
-    std::function<void(const VecStr_t&)> action = nullptr;
+    CommandDef( std::string cmd, size_t nargs,
+                std::function<void(const VecStr_t&)> action )
+      : cmd_{std::move(cmd)}, nargs_{nargs}, action_{std::move(action)} {}
+    std::string cmd_{};
+    size_t nargs_{0};
+    std::function<void(const VecStr_t&)> action_{nullptr};
   };
   static int ParseCommands( ConfLines_t::const_iterator pos,
                             ConfLines_t::const_iterator end,

--- a/panguin.cc
+++ b/panguin.cc
@@ -43,7 +43,7 @@ int main( int argc, char** argv )
   cli.add_option("-E,--plot-format", plotfmt,
                  "Plot format (pdf, png, jpg ...)")
     ->type_name("<fmt>");
-  cli.add_option("-C,--config-dir", cfgdir,
+  cli.add_option("-C,--config-path,--config-dir", cfgdir,
                  "Search path for configuration files & macros "
                  "(\":\"-separated)")
     ->type_name("<path>");
@@ -74,11 +74,10 @@ int main( int argc, char** argv )
       imgdir = pltdir;
   }
 
-  if( verbosity <= 0 ) {
-    verbosity = 0;
-  } else if( verbosity > 0 ) {
+  if( verbosity > 0 )
     cout << cli.config_to_str(true, false);
-  }
+  else
+    verbosity = 0;
 
   if( !gSystem->AccessPathName("./rootlogon.C") ) {
     gROOT->ProcessLine(".x rootlogon.C");

--- a/panguin.cc
+++ b/panguin.cc
@@ -24,72 +24,72 @@ int main( int argc, char** argv )
   bool printonly{false};
   bool saveImages{false};
 
+  CLI::App cli("panguin: configurable ROOT data visualization tool");
+
+  cli.add_option("-f,--config-file", cfgfile,
+                 "Job configuration file")
+    ->capture_default_str()->type_name("<file name>");
+  cli.add_option("-r,--run", run,
+                 "Run number")
+    ->type_name("<run number>");
+  cli.add_option("-R,--root-file", rootfile,
+                 "ROOT file to process")
+    ->type_name("<file name>");
+  cli.add_option("-G,--goldenroot-file", goldenfile,
+                 "Reference ROOT file")
+    ->type_name("<file name>");
+  cli.add_flag("-P,-b,--batch", printonly,
+               "No GUI. Save plots to summary file(s)");
+  cli.add_option("-E,--plot-format", plotfmt,
+                 "Plot format (pdf, png, jpg ...)")
+    ->type_name("<fmt>");
+  cli.add_option("-C,--config-dir", cfgdir,
+                 "Search path for configuration files & macros "
+                 "(\":\"-separated)")
+    ->type_name("<path>");
+  cli.add_option("--root-dir", rootdir,
+                 "ROOT files search path (\":\"-separated)")
+    ->type_name("<path>");
+  cli.add_option("-O,--plots-dir", pltdir,
+                 "Output directory for summary plots")
+    ->type_name("<dir>");
+  cli.add_flag("-I,--images", saveImages,
+               "Save individual plots as images (implies -P)");
+  cli.add_option("-F,--image-format", imgfmt,
+                 "Image file format (png, jpg ...)")
+    ->type_name("<fmt>");
+  cli.add_option("-H,--images-dir", imgdir,
+                 "Output directory for individual images (default: plots-dir)")
+    ->type_name("<dir>");
+  cli.add_option("-v,--verbosity", verbosity,
+                 "Set verbosity level (>=0)")
+    ->type_name("<level>");
+  cli.set_version_flag("-V,--version", PANGUIN_VERSION);
+
+  CLI11_PARSE(cli, argc, argv)
+
+  if( saveImages ) {
+    printonly = true;
+    if( imgdir.empty() )
+      imgdir = pltdir;
+  }
+
+  if( verbosity <= 0 ) {
+    verbosity = 0;
+  } else if( verbosity > 0 ) {
+    cout << cli.config_to_str(true, false);
+  }
+
+  if( !gSystem->AccessPathName("./rootlogon.C") ) {
+    gROOT->ProcessLine(".x rootlogon.C");
+  }
+
+  if( !gSystem->AccessPathName("~/rootlogon.C") ) {
+    gROOT->ProcessLine(".x ~/rootlogon.C");
+  }
+
+  TApplication theApp("panguin", &argc, argv, nullptr, -1);
   try {
-    CLI::App cli("panguin: configurable ROOT data visualization tool");
-
-    cli.add_option("-f,--config-file", cfgfile,
-                   "Job configuration file")
-      ->capture_default_str()->type_name("<file name>");
-    cli.add_option("-r,--run", run,
-                   "Run number")
-      ->type_name("<run number>");
-    cli.add_option("-R,--root-file", rootfile,
-                   "ROOT file to process")
-      ->type_name("<file name>");
-    cli.add_option("-G,--goldenroot-file", goldenfile,
-                   "Reference ROOT file")
-      ->type_name("<file name>");
-    cli.add_flag("-P,-b,--batch", printonly,
-                 "No GUI. Save plots to summary file(s)");
-    cli.add_option("-E,--plot-format", plotfmt,
-                   "Plot format (pdf, png, jpg ...)")
-      ->type_name("<fmt>");
-    cli.add_option("-C,--config-dir", cfgdir,
-                   "Search path for configuration files & macros "
-                   "(\":\"-separated)")
-      ->type_name("<path>");
-    cli.add_option("--root-dir", rootdir,
-                   "ROOT files search path (\":\"-separated)")
-      ->type_name("<path>");
-    cli.add_option("-O,--plots-dir", pltdir,
-                   "Output directory for summary plots")
-      ->type_name("<dir>");
-    cli.add_flag("-I,--images", saveImages,
-                 "Save individual plots as images (implies -P)");
-    cli.add_option("-F,--image-format", imgfmt,
-                   "Image file format (png, jpg ...)")
-      ->type_name("<fmt>");
-    cli.add_option("-H,--images-dir", imgdir,
-                   "Output directory for individual images (default: plots-dir)")
-      ->type_name("<dir>");
-    cli.add_option("-v,--verbosity", verbosity,
-                   "Set verbosity level (>=0)")
-      ->type_name("<level>");
-    cli.set_version_flag("-V,--version", PANGUIN_VERSION);
-
-    CLI11_PARSE(cli, argc, argv)
-
-    if( saveImages ) {
-      printonly = true;
-      if( imgdir.empty() )
-        imgdir = pltdir;
-    }
-
-    if( verbosity <= 0 ) {
-      verbosity = 0;
-    } else if( verbosity > 0 ) {
-      cout << cli.config_to_str(true, false);
-    }
-
-    if( !gSystem->AccessPathName("./rootlogon.C") ) {
-      gROOT->ProcessLine(".x rootlogon.C");
-    }
-
-    if( !gSystem->AccessPathName("~/rootlogon.C") ) {
-      gROOT->ProcessLine(".x ~/rootlogon.C");
-    }
-
-    TApplication theApp("panguin2", &argc, argv, nullptr, -1);
     auto gui
       = online({cfgfile, cfgdir, rootfile, goldenfile, rootdir, plotfmt,
                 imgfmt, pltdir, imgdir, run, verbosity, printonly,
@@ -103,6 +103,7 @@ int main( int argc, char** argv )
 
   } catch ( const exception& e ) {
     cerr << "Error while running panguin: " << e.what() << endl;
+    theApp.Terminate(1);
     return 1;
   }
 

--- a/panguin.cc
+++ b/panguin.cc
@@ -8,7 +8,7 @@
 #include <stdexcept>
 #include <memory>
 
-#define PANGUIN_VERSION "Panguin version 2.5 (23-Oct-2022)"
+#define PANGUIN_VERSION "Panguin version 2.6 (12-Dec-2023)"
 
 using namespace std;
 

--- a/src/panguinOnline.cc
+++ b/src/panguinOnline.cc
@@ -187,6 +187,7 @@ void OnlineGUI::CreateGUI( const TGWindow* p, UInt_t w, UInt_t h )
 
   // Create the main frame
   fMain = new TGMainFrame(p, w, h);
+  fMain->SetCleanup(kDeepCleanup);
   fMain->Connect("CloseWindow()", "OnlineGUI", this, "MyCloseWindow()");
   ULong_t lightgreen, lightblue, red, mainguicolor;
   gClient->GetColorByName("lightgreen", lightgreen);
@@ -1338,21 +1339,8 @@ void OnlineGUI::DeleteGUI()
 {
   DelPtr(timer);
   DelPtr(timerNow);
-  DelPtr(fPrint);
-  DelPtr(fExit);
-  DelPtr(fRunNumber);
-  DelPtr(fPrev);
-  DelPtr(fNext);
-  DelPtr(wile);
-  DelPtr(fNow);
-  DelPtr(fRootFileLastUpdated);
-  DelPtr(fPageListBox);
-  DelPtr(hframe);
-  DelPtr(fEcanvas);
-  DelPtr(vframe);
-  DelPtr(fBottomFrame);
-  DelPtr(fTopframe);
-  DelPtr(fMain);
+  fMain->Cleanup();   // Without this, ROOT will crash on exit
+  //DelPtr(fMain);    // Don't. ROOT will clean it up on exit
 }
 
 //_____________________________________________________________________________

--- a/src/panguinOnline.cc
+++ b/src/panguinOnline.cc
@@ -221,7 +221,7 @@ void OnlineGUI::CreateGUI( const TGWindow* p, UInt_t w, UInt_t h )
   fMain->AddFrame(fTopframe, new TGLayoutHints(kLHintsExpandX
                                                | kLHintsExpandY, 10, 10, 10, 1));
 
-  // Create a verticle frame widget
+  // Create a vertical frame widget
   //  This will hold the listbox
   vframe = new TGVerticalFrame(fTopframe, UInt_t(w * 0.3), UInt_t(h * 0.9));
   vframe->SetBackgroundColor(mainguicolor);
@@ -1261,7 +1261,7 @@ void OnlineGUI::PrintToFile()
 void OnlineGUI::PrintPages()
 {
   // Routine to go through each defined page, and print the output to
-  // a postscript file. (good for making sample histograms).
+  // a PDF file. (good for making sample histograms).
 
   if( !fRootFile )
     throw runtime_error("No ROOT file");

--- a/src/panguinOnlineConfig.cc
+++ b/src/panguinOnlineConfig.cc
@@ -588,11 +588,11 @@ bool OnlineConfig::ParseConfig()
         fMonitor = true;
       }},
       {"2DbinsX",
-        0, [&]( const VecStr_t& line ) {
+        1, [&]( const VecStr_t& line ) {
         hist2D_nBinsX = stoi(line[1]);
       }},
       {"2DbinsY",
-        0, [&]( const VecStr_t& line ) {
+        1, [&]( const VecStr_t& line ) {
         hist2D_nBinsY = stoi(line[1]);
       }},
       {"definecut",

--- a/src/panguinOnlineConfig.cc
+++ b/src/panguinOnlineConfig.cc
@@ -111,7 +111,8 @@ OpenInPath( const string& filename, const string& path, ifstream& infile )
       foundpath.clear();
       infile.setstate(ios_base::failbit);
     }
-  }
+  } else
+    foundpath.clear();
   return foundpath;
 }
 
@@ -351,7 +352,8 @@ OnlineConfig::OnlineConfig( const CmdLineOpts& opts )
     cerr << e.what() << endl;
     fFoundCfg = false;
   }
-  if( ret > 0 )
+  infile.close();
+  if( ret >= 0 )
     cout << sConfFile.size() << " total configuration lines read" << endl;
 }
 
@@ -579,6 +581,7 @@ bool OnlineConfig::ParseConfig()
 
   try {
     // Find "newpage" commands and store their locations and lengths
+    pageInfo.clear();
     auto first_page = ParsePageInfo(ALL(sConfFile), pageInfo);
 
     // List of defined commands and corresponding actions
@@ -776,7 +779,7 @@ bool OnlineConfig::ParseConfig()
 // Returns the defined cut, according to the identifier
 const string& OnlineConfig::GetDefinedCut( const string& ident )
 {
-  static const string nullstr{};
+  static const string nullstr;
 
   for( const auto& cut: cutList ) {
     if( cut.first == ident ) {
@@ -791,6 +794,7 @@ const string& OnlineConfig::GetDefinedCut( const string& ident )
 vector<string> OnlineConfig::GetCutIdent()
 {
   vector<string> out;
+  out.reserve(cutList.size());
 
   for( const auto& cut: cutList ) {
     out.push_back(cut.first);

--- a/src/panguinOnlineConfig.cc
+++ b/src/panguinOnlineConfig.cc
@@ -537,24 +537,31 @@ int OnlineConfig::ParseCommands( ConfLines_t::const_iterator pos,
   for( ; pos != end; ++pos ) {
     const auto& line = *pos;
     for( const auto& item: items ) {
-      if( item.cmd != line[0] )
+      if( item.cmd_ != line[0] )
         continue;
       auto narg = line.size()-1;
-      if( narg != item.narg ) {
-        if( narg < item.narg ) {
-          cerr << "ERROR: not enough arguments for " << item.cmd << " command,"
-               << "needs " << item.narg << ", found " << narg
+      size_t required_nargs = item.nargs_;
+      bool exact = true;  // Number of arguments must match exactly
+      if( required_nargs >= 100 ) {
+        required_nargs %= 100;
+        exact = false;
+      }
+      if( narg != required_nargs ) {
+        if( narg < required_nargs ) {
+          cerr << "ERROR: not enough arguments for " << item.cmd_ << " command,"
+               << "needs " << required_nargs << ", found " << narg
                << ". Command skipped." << endl;
           continue;
-        } else
-          cerr << "WARNING: too many arguments for " << item.cmd << " command,"
-               << "expect " << item.narg << ", found " << narg
+        } else if( exact ) {
+          cerr << "WARNING: too many arguments for " << item.cmd_ << " command,"
+               << "expect " << required_nargs << ", found " << narg
                << ", ignoring extras" << endl;
+        }
       }
-      if( item.action )
-        item.action(line);
+      if( item.action_ )
+        item.action_(line);
       else
-        cerr << "WARNING: no action for " << item.cmd << " command? "
+        cerr << "WARNING: no action for " << item.cmd_ << " command? "
              << "Call expert." << endl;
       break;
     }


### PR DESCRIPTION
Main changes:

- Fix crash on exit due to double-delete of GUI elements in ROOT TApplication destructor
- Support single and double quotes in config files in line with common user expectations
- Honor -nostat option for macro plots (unless the macro explicitly overrides it), tree variable plots, and saved images. Fixes issue #13. 
- Smaller bugfixes and improvements
- Update version to 2.6

Incidentally, since there are absolutely zero commits on the main branch that would need to be merged, I suggest to pick "Rebase and merge" to accept this PR.
